### PR TITLE
Prevent error when user has no picture

### DIFF
--- a/library.js
+++ b/library.js
@@ -82,7 +82,7 @@
                         'text'     : message,
                         'channel'  : (Slack.config['channel'] || '#general'),
                         'username' : data.user.username,
-                        'icon_url' : data.user.picture.match(/^\/\//) ? 'http:' + data.user.picture : data.user.picture
+                        'icon_url' : data.user.picture && data.user.picture.match(/^\/\//) ? 'http:' + data.user.picture : data.user.picture
                     }, function(err, response) {
                         if (err) {
                             console.log(err);


### PR DESCRIPTION
When user has no picture, this error occurs and causes restart of NodeBB process:

```js
2020-10-09T05:47:25.506Z [4569/8115] - error: uncaughtException: Cannot read property 'match' of null
TypeError: Cannot read property 'match' of null
    at /usr/src/app/node_modules/nodebb-plugin-slack-extended/library.js:85:56
    at /usr/src/app/node_modules/async/dist/async.js:2955:19
    at wrapper (/usr/src/app/node_modules/async/dist/async.js:268:20)
    at iterateeCallback (/usr/src/app/node_modules/async/dist/async.js:421:28)
    at /usr/src/app/node_modules/async/dist/async.js:321:20
    at /usr/src/app/node_modules/async/dist/async.js:2953:17
    at /usr/src/app/src/promisify.js:46:33
    at cb (util.js:207:31)
```